### PR TITLE
Add empty addons and default_process_types

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,4 +1,6 @@
 #!/bin/sh
 
 cat << EOF
+addons: []
+default_process_types: {}
 EOF


### PR DESCRIPTION
According to [Buildpack API](https://devcenter.heroku.com/articles/buildpack-api#bin-release) `addons` and `default_process_types` should be returned. Missing entries causes this [issue](https://github.com/progrium/dokku/issues/676).
