### PR TITLE
Fixes #4, lacks documentation

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -36,7 +36,7 @@ message "Skipping Installing jekyll"
 if [ ! -f Procfile ]
 then
     message "no Procfile found, providing default"
-    echo "web: env bundle exec jekyll serve --port \$PORT" > Procfile
+    echo "web: env bundle exec jekyll serve --host 0.0.0.0 --port \$PORT" > Procfile
 fi
 
 # Run Jekyll

--- a/bin/compile
+++ b/bin/compile
@@ -13,17 +13,12 @@ message() {
 cd $BUILD_ROOT
 
 message "Setting environment variables"
-export GEM_HOME=$BUILD_ROOT/.gems
-export PATH=$BUILD_ROOT/.gems/bin:$PATH
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF8
 
 # Install Jekyll into BUILD_ROOT/.gems
 cat << EOF > ~/.gemrc
 gem: --no-ri --no-rdoc
-gemhome: $BUILD_ROOT/.gems
-gempath:
-- $BUILD_ROOT/.gems
 EOF
 
 message "Installing jekyll"
@@ -41,7 +36,7 @@ fi
 if [ ! -f Procfile ]
 then
     message "no Procfile found, providing default"
-    echo "web: env GEM_HOME=./.gems ./.gems/bin/jekyll serve --port \$PORT" > Procfile
+    echo "web: env jekyll serve --port \$PORT" > Procfile
 fi
 
 # Run Jekyll

--- a/bin/compile
+++ b/bin/compile
@@ -16,29 +16,29 @@ message "Setting environment variables"
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF8
 
-# Install Jekyll into BUILD_ROOT/.gems
-cat << EOF > ~/.gemrc
-gem: --no-ri --no-rdoc
-EOF
+## Install Jekyll into BUILD_ROOT/.gems
+#cat << EOF > ~/.gemrc
+#gem: --no-ri --no-rdoc
+#EOF
 
-message "Installing jekyll"
-gem install jekyll
+message "Skipping Installing jekyll"
+#gem install jekyll
 
 # Install dependencies if a Gemfile is present
-if [ -f Gemfile ]
-then
-    message "installing bundled dependencies"
-    gem install bundler
-    bundle install
-fi
+#if [ -f Gemfile ]
+#then
+#    message "installing bundled dependencies"
+#    gem install bundler
+#    bundle install
+#fi
 
 # inject a Procfile if none is present
 if [ ! -f Procfile ]
 then
     message "no Procfile found, providing default"
-    echo "web: env jekyll serve --port \$PORT" > Procfile
+    echo "web: env bundle exec jekyll serve --port \$PORT" > Procfile
 fi
 
 # Run Jekyll
 message "Compiling Jekyll site"
-jekyll build | indent
+bundle exec jekyll build | indent


### PR DESCRIPTION
```
heroku[web.1]: State changed from starting to up
```

Related to #4 - could not deploy with a current cedar stack

Fixed for me, needs documentation or at least an announcement in message to be merge-able

The user is now responsible for adding buildpacks (using [ddollar/heroku-buildpack-multi](/ddollar/heroku-buildpack-multi) providing ruby and jekyll, pygments.rb, kramdown  and nodejs, they had all been removed from cedar stack 14 if they were included before.

Needs documentation, but at least there is this: [yebyen/jekyll-bacongobbler](/yebyen/jekyll-bacongobbler): a minimal, current example of "how to deploy from `jekyll new .` default generated site".  Does away with the old .gems/ local gemset thing, the user is also responsible for adding a Gemfile that brings in `jekyll`, `pygments.rb`, and `kramdown` as far as I can tell.  All of this is shown in [yebyen/jekyll-bacongobbler](/yebyen/jekyll-bacongobbler).
